### PR TITLE
EU footer updated

### DIFF
--- a/views/main.pug
+++ b/views/main.pug
@@ -32,7 +32,8 @@ block content
               div.col-6.footer-image-container
                 img(src="/eu.jpg").footer-image
               div.col-6.footer-text-eu.text-start
-                | Funded by the Horizon 2020 Framework Programme of the European Union
+                | Funded by
+                | the European Union
 
       div.col-lg-4.home-leftcol.order-lg-1
         div.row.justify-content-center.full-height
@@ -92,7 +93,8 @@ block content
               div.col-4.footer-image-container
                 img(src="/eu.jpg").footer-image
               div.col-8.footer-text-eu.text-start
-                | Funded by the Horizon 2020 Framework Programme of the European Union
+                | Funded by
+                | the European Union
           div.button.col-10.footer-add.d-block.d-lg-none
             div.row
               div.col-4.footer-image-container


### PR DESCRIPTION
The visual identity of Horizon Europe demands a different text.

I just guessed the syntax of the source code and edited the file accordingly. Please check the official logo from COST visual identity Horizon Europe Zip file from [here](https://www.cost.eu/about/visual-identity/) that it looks right.